### PR TITLE
For link rel="icon", accept "image/..." as type, not only "image".

### DIFF
--- a/lib/img.js
+++ b/lib/img.js
@@ -4,6 +4,7 @@ const imgSVG = require('./imgSVG.js');
 const { getAttributeString } = require('./utils');
 
 const RE_XML_TAG = /<\?xml.+?\?>\s+/g;
+const RE_IMAGE_MIMETYPE = /^image(\/\S+)$/;
 
 let svgo;
 
@@ -14,8 +15,12 @@ let svgo;
  * @returns {Promise}
  */
 module.exports = function img(source, context) {
-  return new Promise(async (resolve) => {
-    if (source.fileContent && !source.content && source.type == 'image') {
+  return new Promise((resolve) => {
+    if (
+      source.fileContent &&
+      !source.content &&
+      RE_IMAGE_MIMETYPE.test(source.type)
+    ) {
       const attributeType = source.attributes.type;
       let strict = !source.errored;
       let sourceProp = 'src';
@@ -42,7 +47,7 @@ module.exports = function img(source, context) {
           });
         }
         if (!source.svgAsImage) {
-          await imgSVG(source, context, svgo);
+          imgSVG(source, context, svgo);
           return resolve();
         }
 
@@ -50,7 +55,7 @@ module.exports = function img(source, context) {
         // Strip xml tag
         source.content = source.fileContent.replace(RE_XML_TAG, '');
         if (source.compress) {
-          const result = await svgo.optimize(source.content);
+          const result = svgo.optimize(source.content);
 
           source.content = result.data;
         }


### PR DESCRIPTION
This patch is needed to be able to inline tags like
`<link inline href="../images/favicon.ico" rel="icon" type="image/x-icon">`
because the original code recognizes only `type="image"`.

Also, the Promise resolution function is no longer async, due to git pre-hook lint check failure.